### PR TITLE
Add automatic map finder, refactor some logic

### DIFF
--- a/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/Maps.java
+++ b/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/Maps.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class Maps implements Dropdown.Options<String> {
-    private static final List<String> OPTIONS = Arrays.asList("X-1", "X-8", "5-2", "LoW");
+    private static final List<String> OPTIONS = Arrays.asList("Auto", "X-1", "X-8", "5-2", "LoW");
 
     @Override
     public String getText(String option) {

--- a/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/OreTraderConfig.java
+++ b/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/OreTraderConfig.java
@@ -3,50 +3,50 @@ package eu.darkbot.kekawce.modules.tradertmpmodule;
 import com.github.manolo8.darkbot.config.Config;
 import com.github.manolo8.darkbot.config.types.Num;
 import com.github.manolo8.darkbot.config.types.Option;
+import eu.darkbot.api.config.annotations.Configuration;
 import eu.darkbot.api.config.annotations.Dropdown;
 import eu.darkbot.api.managers.OreAPI;
 
-import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 
+@Configuration("ore_trader.config")
 public class OreTraderConfig {
-    @Option(value = "Enable feature", description = "check this to enable this feature/plugin")
+    @Option(value = "Enabled", description = "Check this to enable this feature/plugin")
     public boolean ENABLE_FEATURE = false;
 
-    @Option(value = "Sell map", description = "goes to this map to sell resources")
+    @Option(value = "Sell map", description = "Goes to this map to sell resources")
     @Dropdown(options = Maps.class)
-    public String SELL_MAP = "X-1";
+    public String SELL_MAP = "Auto";
 
-    @Option(value = "Sell config", description = "changes to this config when selling")
+    @Option(value = "Resources to sell", description = "Will only sell the selected resources")
+    @Dropdown(options = Ores.class, multi = true)
+    public Set<OreAPI.Ore> ORES_TO_SELL = new HashSet<>(Ores.ORES);
+
+    @Option(value = "Sell Config", description = "Changes to this config when flying/selling")
     public Config.ShipConfig SELL_CONFIG = new Config.ShipConfig(2, '9');
 
-    @Option(value = "Finish current target before selling", description = "will kill current target before travelling to base to sell")
+    @Option(value = "Finish current target", description = "Will kill current target before travelling to base to sell")
     public boolean FINISH_TARGET_BEFORE_SELLING = false;
-
-    @Option(value = "Resources to sell", description = "will only sell these selected resources")
-    @Dropdown(multi = true)
-    public Set<OreAPI.Ore> ORES_TO_SELL = EnumSet.allOf(OreAPI.Ore.class);
 
     @Option(value = "Advanced", description = "You can ignore this if you have no issues")
     public Advanced ADVANCED = new Advanced();
 
     public static class Advanced {
-        @SuppressWarnings("DefaultAnnotationParam")
         @Option(
-                value = "Wait before starting to sell(ms)",
+                value = "Wait before starting to sell (ms)",
                 description = "This is how long the bot will wait before starting to sell" +
-                        "\nIncrease it if you find your ship stuck moving before selling" +
-                        "\nOtherwise decrease it if you want to speed up this action"
+                              "\nIncrease it if you find your ship stuck moving before selling" +
+                              "\nOtherwise decrease it if you want to speed up this action"
         )
         @Num(min = 0, max = 5000, step = 100)
         public int SELL_WAIT = 2000;
 
-        @SuppressWarnings("DefaultAnnotationParam")
         @Option(
-                value = "Sell delay(ms)",
+                value = "Sell delay (ms)",
                 description = "This is the delay between selling each resource" +
-                        "\nIncrease it if you find that some resources have been skipped during selling" +
-                        "\nOtherwise decrease it if you want to speed up this action"
+                              "\nIncrease it if you find that some resources have been skipped during selling." +
+                              "\nOtherwise decrease it if you want to speed up selling"
         )
         @Num(min = 0, max = 1000, step = 100)
         public int SELL_DELAY = 300;

--- a/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/OreTraderConfig.java
+++ b/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/OreTraderConfig.java
@@ -40,7 +40,7 @@ public class OreTraderConfig {
                               "\nOtherwise decrease it if you want to speed up this action"
         )
         @Num(min = 0, max = 5000, step = 100)
-        public int SELL_WAIT = 2000;
+        public long SELL_WAIT = 2000;
 
         @Option(
                 value = "Sell delay (ms)",
@@ -49,6 +49,6 @@ public class OreTraderConfig {
                               "\nOtherwise decrease it if you want to speed up selling"
         )
         @Num(min = 0, max = 1000, step = 100)
-        public int SELL_DELAY = 300;
+        public long SELL_INTERVAL = 300;
     }
 }

--- a/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/Ores.java
+++ b/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/Ores.java
@@ -1,0 +1,28 @@
+package eu.darkbot.kekawce.modules.tradertmpmodule;
+
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.managers.OreAPI.Ore;
+import eu.darkbot.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class Ores implements Dropdown.Options<Ore> {
+
+	public static final List<Ore> ORES = Arrays.stream(Ore.values()).filter(Ore::isSellable).collect(Collectors.toList());
+
+	@Override
+	public Collection<Ore> options() {
+		return ORES;
+	}
+
+	@Override
+	public String getText(Ore ore) {
+		if (ore != null) return StringUtils.capitalize(ore.getName());
+		return Objects.toString(null);
+	}
+}
+

--- a/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/StarSystemHelper.java
+++ b/src/main/java/eu/darkbot/kekawce/modules/tradertmpmodule/StarSystemHelper.java
@@ -1,0 +1,123 @@
+package eu.darkbot.kekawce.modules.tradertmpmodule;
+
+import com.github.manolo8.darkbot.core.manager.StarManager;
+import eu.darkbot.api.game.entities.Station;
+import eu.darkbot.api.game.other.EntityInfo;
+import eu.darkbot.api.game.other.GameMap;
+import eu.darkbot.api.managers.EntitiesAPI;
+import eu.darkbot.api.managers.HeroAPI;
+import eu.darkbot.api.managers.StarSystemAPI;
+import eu.darkbot.util.ArrayUtils;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class StarSystemHelper {
+	protected static final List<String> LOWERS = ArrayUtils.asImmutableList("1-1", "1-2", "1-3", "1-4", "2-1", "2-2", "2-3", "2-4", "3-1", "3-2", "3-3", "3-4");
+	protected static final List<String> UPPERS = ArrayUtils.asImmutableList("1-5", "1-6", "1-7", "1-8", "2-5", "2-6", "2-7", "2-8", "3-5", "3-6", "3-7", "3-8");
+	protected static final List<String> PVP = ArrayUtils.asImmutableList("4-1", "4-2", "4-3");
+	protected static final List<String> PIRATE = ArrayUtils.asImmutableList("4-4", "4-5", "5-1", "5-2", "5-3", "5-4");
+	protected static final List<String> BLACKLIGHT = StarSystemAPI.BLACK_LIGHT_MAPS;
+	protected static final List<String> BASE_MAPS = StarSystemAPI.BASE_MAPS;
+
+	private final HeroAPI hero;
+	private final StarSystemAPI starSystem;
+	private final EntitiesAPI entities;
+
+	public StarSystemHelper(HeroAPI hero, StarSystemAPI starSystem, EntitiesAPI entities) {
+		this.hero = hero;
+		this.starSystem = starSystem;
+		this.entities = entities;
+	}
+
+	protected enum BaseMap {
+		MMO(1),
+		EIC(5),
+		VRU(9),
+		PIRATE(92);
+
+		private final int mapId;
+
+		BaseMap(int mapId) {
+			this.mapId = mapId;
+		}
+	}
+
+	/** Finds the closes base map with a refinery. */
+	public Optional<GameMap> findRefineryMap() {
+		int factionId = hero.getEntityInfo().getFaction().ordinal();
+		if (factionId == 0 || factionId == 4) return Optional.empty(); // should never happen
+
+		GameMap currentMap = hero.getMap();
+		String currentMapName = currentMap.getName();
+		String HOME = factionId + "-1";
+		String OUTPOST = factionId + "-8";
+		String NEUTRAL = "5-2";
+
+		// while in LoW, stay there
+		if (currentMapName.equals("LoW")) return Optional.of(currentMap);
+		// while in GGs, use home map
+		if (currentMap.isGG()) return starSystem.findMap(HOME);
+
+		// when already in our home or outpost map, stay there
+		if (BASE_MAPS.contains(currentMapName) && isFactionMap()) return Optional.of(currentMap);
+		// check battle maps (4-X) or lowers and go to X-1
+		if (LOWERS.contains(currentMapName) || PVP.contains(currentMapName)) return starSystem.findMap(HOME);
+		// check uppers and blacklight and go to X-8
+		if (UPPERS.contains(currentMapName) || BLACKLIGHT.contains(currentMapName)) return starSystem.findMap(OUTPOST);
+		// check 4-4, 4-5, and 5-X and go to 5-2
+		if (PIRATE.contains(currentMapName)) return starSystem.findMap(NEUTRAL);
+
+		// default to the home map
+		return starSystem.findMap(HOME);
+	}
+
+	/** Tries to find the best map. If not possible, defaults to the faction's home. */
+	public GameMap getRefineryMap(OreTraderConfig config) {
+		String sellMap = config.SELL_MAP;
+		EntityInfo.Faction faction = hero.getEntityInfo().getFaction();
+
+		if (!sellMap.equalsIgnoreCase("auto")) {
+			// X-1, X-8 or LoW
+			String name = config.SELL_MAP.replace("X", String.valueOf(faction.ordinal()));
+			return StarManager.getInstance().byName(name);
+		}
+
+		BaseMap map = BaseMap.PIRATE;
+		switch (faction) {
+			case MMO:
+				map = BaseMap.MMO;
+				break;
+			case EIC:
+				map = BaseMap.EIC;
+				break;
+			case VRU:
+				map = BaseMap.VRU;
+				break;
+		}
+		return findRefineryMap().orElse(starSystem.getOrCreateMap(map.mapId));
+	}
+
+	/** Finds the closes {@link eu.darkbot.api.game.entities.Station.Refinery} in the current map. */
+	public Optional<Station.Refinery> findRefinery() {
+		Collection<? extends Station> bases = this.entities.getStations();
+		return bases.stream()
+						.filter(Objects::nonNull)
+						.filter(b -> b instanceof Station.Refinery && b.getLocationInfo().isInitialized())
+						.map(Station.Refinery.class::cast)
+						.min(Comparator.comparingDouble(p -> p.getLocationInfo().distanceTo(hero)));
+	}
+
+	/**
+	 * Determines whether the current map belongs to the {@link eu.darkbot.api.managers.HeroAPI Hero}'s
+	 * {@link eu.darkbot.api.game.other.EntityInfo.Faction Faction}.
+	 */
+	private boolean isFactionMap() {
+		int factionId = hero.getEntityInfo().getFaction().ordinal();
+		if (factionId == 0 || factionId == 4) return false;
+		return hero.getMap().getName().startsWith(factionId + "-");
+	}
+}


### PR DESCRIPTION
The main feature here is the `StarSystemHelper` class, which implements a simple "best map" finder. It tries to find the nearest refinery, with fallbacks to either X-1 or 5-2.

I've added back the `Ores` dropdown options class to be able to filter by sellable ores.

I've also refactored a lot of logic that was using bot internals to prefer the DarkBotAPI instead, since there were quite a few deprecation warnings. The most important bits here are the `Behaviour` and `Module` tick functions.